### PR TITLE
fix: Sort array when & populate list

### DIFF
--- a/test/complete_me_test.rb
+++ b/test/complete_me_test.rb
@@ -44,10 +44,11 @@ class CompleteMeTest < Minitest::Test
 
   def test_suggests_off_of_medium_dataset
     cm.populate(medium_word_list)
-    assert_equal ["williwaw", "wizardly"], cm.suggest("wi")
+    assert_equal ["williwaw", "wizardly"], cm.suggest("wi").sort
   end
 
   def test_selects_off_of_medium_dataset
+    cm.populate(medium_word_list)
     cm.select("wi", "wizardly")
     assert_equal ["wizardly", "williwaw"], cm.suggest("wi")
   end


### PR DESCRIPTION
Fixes test_suggest_off_medium_dataset by allowing the suggested
words to be in any order by using sort.
Also fixes test_selects_off_medium_dataset by populating the data
set a the beginning of the test, since the tests can run in any order
and it might not always be populated unless you specify that.