### PR TITLE
fix: Update large_word_list & fix array

### DIFF
--- a/test/complete_me_test.rb
+++ b/test/complete_me_test.rb
@@ -55,7 +55,7 @@ class CompleteMeTest < Minitest::Test
 
   def test_works_with_large_dataset
     cm.populate(large_word_list)
-    assert_equal ["doggerel" "doggereler" "doggerelism" "doggerelist" "doggerelize" "doggerelizer"], cm.suggest("doggerel")
+    assert_equal ["doggerel", "doggereler", "doggerelism", "doggerelist", "doggerelize", "doggerelizer"], cm.suggest("doggerel").sort
     cm.select("doggerel", "doggerelist")
     assert_equal "doggerelist", cm.suggest("doggerel").first
   end
@@ -69,6 +69,6 @@ class CompleteMeTest < Minitest::Test
   end
 
   def large_word_list
-    File.read("./test/medium.txt")
+    File.read("/usr/share/dict/words")
   end
 end


### PR DESCRIPTION
Updates the large_word_list method to use the built-in Mac dictionary.
Also fixes the array in test_works_with_large_dataset since it was
missing commas between the words. Adds .sort to the first assertion
since the order does not matter there.